### PR TITLE
Media index bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Folders
+cometspy/__pycache__/*
+
+# Package files
+*.egg-info/*
+
+# pyc files
+*.pyc

--- a/cometspy/layout.py
+++ b/cometspy/layout.py
@@ -613,6 +613,22 @@ class layout:
         ids = [x.id for x in self.models]
         return(ids)
 
+    def get_model(self, model_id):
+        """
+        Get a comets model object from the model ID. Return None if the model is not found.s
+
+        Parameters
+        ----------
+        model_id: str,
+            model id
+
+        """
+        for model in self.models:
+            if model.id == model_id:
+                return model
+
+        return None
+
     def write_necessary_files(self, working_dir : str):
         """
         writes the layout and the model files to file

--- a/cometspy/layout.py
+++ b/cometspy/layout.py
@@ -1056,6 +1056,10 @@ class layout:
         # right now we only check if a user manually set a diff_c.  Ideally,
         # we should check for manual changes to everything. Alternatively,
         # we should print all blocks no matter what. 
+        
+        # Reset index of media - avoids downstream errors
+        self.media = self.media.reset_index(drop=True)
+
         self.__check_if_diffusion_flag_should_be_set()
         outfile = working_dir + ".current_layout"
         if os.path.isfile(outfile):

--- a/cometspy/layout.py
+++ b/cometspy/layout.py
@@ -615,7 +615,7 @@ class layout:
 
     def get_model(self, model_id):
         """
-        Get a comets model object from the model ID. Return None if the model is not found.s
+        Get a comets model object from the model ID. Return None if the model is not found.
 
         Parameters
         ----------

--- a/cometspy/model.py
+++ b/cometspy/model.py
@@ -328,6 +328,12 @@ class model:
         exchmets = self.metabolites.iloc[exchmets-1]
         return(exchmets.METABOLITE_NAMES)
 
+    def get_exchange_reactions(self) -> list:
+        """
+        Returns a list of all exchange reactions
+        """
+        return self.reactions.loc[self.reactions['EXCH'], "REACTION_NAMES"]
+
     def change_bounds(self, reaction : str, lower_bound : float, upper_bound : float):
         """ changes the bounds of the specified reaction
         


### PR DESCRIPTION
The main contribution is here one single line `self.media = self.media.reset_index(drop=True)` in `layout.py` that resolves an issue I encountered several times with non-unique indices in the `self.media` dataframe. 

The other addtitions are a very basic .gitignore file and two helper functions to get variables - I can remove this edits if they are unwanted.