### PR TITLE
Add spaces in warning messages

### DIFF
--- a/cometspy/layout.py
+++ b/cometspy/layout.py
@@ -442,8 +442,9 @@ class layout:
             for i in range(lin_diff+1, lin_diff_end):
                 diff_spec = [float(x) for x in f_lines[i].split()]
                 if diff_spec[0] > len(self.media.metabolite)-1:
-                    print('\n Warning: Corrupt line ' + str(i) + ' in diffusion' +
-                          'values. \nLine not written. Check your layout file.')
+                    print('\n Warning: Corrupt line ' + str(i) + ' in ' +
+                          'diffusion values. \nLine not written. Check your ' +
+                          'layout file.')
                 else:
                     self.media.loc[int(diff_spec[0]),
                                    'diff_c'] = diff_spec[1]

--- a/cometspy/layout.py
+++ b/cometspy/layout.py
@@ -825,7 +825,7 @@ class layout:
             self.media = pd.concat([self.media,
                                     newrow],
                                    axis=0, sort=False)
-            print('Warning: The added metabolite (' + met + ') is not' +
+            print('Warning: The added metabolite (' + met + ') is not ' +
                   'able to be taken up by any of the current models')
 
     def set_specific_metabolite_at_location(self, met : str, 


### PR DESCRIPTION
There were some warnings that were combining words when printed because there was no space between the words when the strings were added together, i.e.:
```python
print('Warning: The added metabolite (' + met + ') is not' +
      'able to be taken up by any of the current models')
```
(https://github.com/segrelab/cometspy/blob/master/cometspy/layout.py#L828-829)

That specific line was mentioned in #25.

I found one other line that had a similar problem, and fixed that too.

