### PR TITLE
allow objective function to be a sum of multiple reactions

### DIFF
--- a/cometspy/model.py
+++ b/cometspy/model.py
@@ -628,11 +628,13 @@ class model:
         if hasattr(curr_m, 'default_bounds'):
             self.default_bounds = curr_m.default_bounds
 
-        obj = [str(x).split(':')[0]
-               for x in reaction_list
-               if x.objective_coefficient != 0][0]
-        self.objective = int(self.reactions[self.reactions.
-                                            REACTION_NAMES == obj]['ID'])
+        obj = {str(x).split(':')[0]:x.objective_coefficient 
+               for x in reaction_list 
+               if x.objective_coefficient != 0}
+        obj = {rx: -1 if coef < 0 else 1 for rx, coef in obj.items()}
+
+        self.objective = [int(self.reactions[self.reactions.
+                                             REACTION_NAMES == rx]['ID']) * coef for rx, coef in obj.items()]
 
         if hasattr(curr_m, 'comets_optimizer'):
             self.optimizer = curr_m.comets_optimizer
@@ -980,7 +982,7 @@ class model:
             f.write(r'//' + '\n')
 
             f.write('OBJECTIVE\n' +
-                    '    ' + str(self.objective) + '\n')
+                    '    ' + '    '.join([str(rx) for rx in self.objective]) + '\n')
             f.write(r'//' + '\n')
 
             f.write('METABOLITE_NAMES\n')


### PR DESCRIPTION
When loading a cobrapy model, cometspy was saving only the first reaction in the objective function as the objective attribute (https://github.com/segrelab/cometspy/blob/master/cometspy/model.py#L631-L635), despite COMETS allowing multiple reactions to be specified as objective in the .cmd file.

Two small changes were made:
1. Changed the way that the objective function from a cobrapy model is loaded. Followed the COMETS convention of putting "-" in front of reaction id for reactions that are to be minimised and assuming all other reactions are to be maximised.
2. Changed the way that the objective is written to a .cmd file. Multiple reaction id's are written on the same line and separated by whitespace.