### PR TITLE
Addition of progress bar to comets.run()

### DIFF
--- a/cometspy.egg-info/requires.txt
+++ b/cometspy.egg-info/requires.txt
@@ -1,3 +1,4 @@
 numpy
 cobra
 pandas>=1.0.0
+tqdm


### PR DESCRIPTION
This branch adds a progress bar to the `comets.run()` function to make it easier to track progress of longer experiments, such as those that have a large number of cycles or those where each cycle takes a long time due to GEM complexity.

The code utilizes [tqdm](https://tqdm.github.io) for the progress bar functionality, and tqdm automatically displays the correct progress bar format depending on whether the session is started in a terminal or a Jupyter/IPython notebook. The progress bar is able to be disabled via the `progress` argument in `comets.run()`.