### PR TITLE
Removal of deprecation warnings and FutureWarnings associated with pandas

### DIFF
--- a/cometspy/comets.py
+++ b/cometspy/comets.py
@@ -456,12 +456,12 @@ class comets:
             max_rows = 4 + max([len(m.reactions) for m in self.layout.models])
 
             self.fluxes = pd.read_csv(self.working_dir + self.parameters.all_params['FluxLogName'],
-                                      delim_whitespace=True,
+                                      sep="\\s+",
                                       header=None, names=range(max_rows))
             # deal with commas-as-decimals
             if any([isinstance(self.fluxes.iloc[0,i], str) for i in range(self.fluxes.shape[1])]):
                 self.fluxes = pd.read_csv(self.working_dir + self.parameters.all_params['FluxLogName'],
-                                      decimal = ",", delim_whitespace=True,
+                                      decimal = ",", sep="\\s+",
                                       header=None, names=range(max_rows))
             if delete_files:
                 os.remove(self.working_dir + self.parameters.all_params['FluxLogName'])
@@ -470,7 +470,7 @@ class comets:
         # Read media logs
         if self.parameters.all_params['writeMediaLog']:
             self.media = pd.read_csv(self.working_dir + self.parameters.all_params[
-                'MediaLogName'], delim_whitespace=True, names=('metabolite',
+                'MediaLogName'], sep="\\s+", names=('metabolite',
                                                                'cycle', 'x',
                                                                'y',
                                                                'conc_mmol'))
@@ -478,7 +478,7 @@ class comets:
             if isinstance(self.media.loc[0, "conc_mmol"], str):
                 self.media = pd.read_csv(self.working_dir + self.parameters.all_params[
                 'MediaLogName'],
-                    decimal = ",", delim_whitespace=True, names=('metabolite',
+                    decimal = ",", sep="\\s+", names=('metabolite',
                                                                'cycle', 'x',
                                                                'y',
                                                                'conc_mmol'))

--- a/cometspy/model.py
+++ b/cometspy/model.py
@@ -657,7 +657,12 @@ class model:
                                 'rxn': [rxn_num]*len(rxn_mets),
                                 's_coef': met_s_coefs})
             cdf = cdf.sort_values('metabolite')
-            self.smat = pd.concat([self.smat, cdf])
+            # skip concatenation on first row (prevents pandas FutureWarning)
+            if index == 0:
+                self.smat = cdf
+            else:
+                self.smat = pd.concat([self.smat, cdf])
+                
 
         self.smat = self.smat.sort_values(by=['metabolite', 'rxn'])
 

--- a/cometspy/model.py
+++ b/cometspy/model.py
@@ -670,13 +670,13 @@ class model:
         if hasattr(curr_m, 'default_bounds'):
             self.default_bounds = curr_m.default_bounds
 
+        # set objective(s) using COBRA reactions objective coefficient information
         obj = {str(x).split(':')[0]:x.objective_coefficient 
                for x in reaction_list 
                if x.objective_coefficient != 0}
         obj = {rx: -1 if coef < 0 else 1 for rx, coef in obj.items()}
 
-        self.objective = [int(self.reactions[self.reactions.
-                                             REACTION_NAMES == rx]['ID']) * coef for rx, coef in obj.items()]
+        self.objective = [int(self.reactions[self.reactions.REACTION_NAMES == rx]['ID'].iloc[0]) * coef for rx, coef in obj.items()]
 
         if hasattr(curr_m, 'comets_optimizer'):
             self.optimizer = curr_m.comets_optimizer


### PR DESCRIPTION
Associated with issue #57.

This fix modifies a few specific steps in the code to remove deprecation warnings / FutureWarnings stemming from use of pandas. Specifically:
1. Changes `delim_whitespace = True` to `sep="\\s+"` in `read_csv` when reading in flux, media, etc. logs
2. Skips concatenation of stoichiometric matrix for the first row to avoid FutureWarning
3.  Changes objective index creation code to avoid FutureWarning